### PR TITLE
Fixed slider bug.

### DIFF
--- a/src/main/java/com/github/miemiedev/mybatis/paginator/domain/Paginator.java
+++ b/src/main/java/com/github/miemiedev/mybatis/paginator/domain/Paginator.java
@@ -217,7 +217,7 @@ public class Paginator implements Serializable {
             endPageNumber = lastPageNumber;
         }
 
-        if (endPageNumber - startPageNumber < count) {
+        if (endPageNumber - startPageNumber + 1 < count) {
             startPageNumber = endPageNumber - count;
             if (startPageNumber <= 0) {
                 startPageNumber = 1;


### PR DESCRIPTION
In the original code, in normal case (the slider is in the middle of all pages), number of pages in slider would be 1 more than "count". Should use "endPageNumber - startPageNumber + 1 < count" to examine if it's the normal case or the slider is on the edge so the "startPageNumber" should be recalculated.
